### PR TITLE
Use service object to seprate logic | Use I18n to refactor Course helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,4 +4,7 @@ Style/Documentation:
   Enabled: false
 Lint/MissingSuper:
   Exclude:
-    - 'app/services/**/*'
+    - "app/services/**/*"
+AllCops:
+  Exclude:
+    - "db/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Lint/MissingSuper:
+  Exclude:
+    - 'app/services/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.1.2'
 
+gem 'rails-i18n'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.4'
 

--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,5 @@ gem 'devise'
 gem 'letter_opener', group: :development
 gem 'pry-rails'
 gem 'sidekiq'
+
+gem 'ruby-lsp', '~> 0.3.2', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.4)
       actionpack (= 7.0.4)
       activesupport (= 7.0.4)
@@ -273,6 +276,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.4)
+  rails-i18n
   ruby-lsp (~> 0.3.2)
   selenium-webdriver
   sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    language_server-protocol (3.17.0.1)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.8.1)
@@ -151,6 +152,7 @@ GEM
     nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    prettier_print (0.1.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -198,6 +200,10 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    ruby-lsp (0.3.2)
+      language_server-protocol (~> 3.17.0)
+      sorbet-runtime
+      syntax_tree (>= 3.4)
     rubyzip (2.3.2)
     selenium-webdriver (4.4.0)
       childprocess (>= 0.5, < 5.0)
@@ -208,6 +214,7 @@ GEM
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sorbet-runtime (0.5.10461)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -219,6 +226,8 @@ GEM
     stimulus-rails (1.1.0)
       railties (>= 6.0.0)
     strscan (3.0.4)
+    syntax_tree (3.6.1)
+      prettier_print
     tailwindcss-rails (2.0.13-arm64-darwin)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -264,6 +273,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.4)
+  ruby-lsp (~> 0.3.2)
   selenium-webdriver
   sidekiq
   sprockets-rails

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -4,9 +4,6 @@ class CoursesController < ApplicationController
   before_action :is_admin, only: %i[new create destroy update edit]
 
   def index
-    # binding.pry
-    # flash[:notice] = "Welciome tmmmm"
-
     @courses = if params[:query].blank?
                  Course.all
                else
@@ -19,13 +16,8 @@ class CoursesController < ApplicationController
   end
 
   def show
-    @number_of_enrolled_count = @course.users.size
+    @number_of_enrolled_count = @course.subscribers.size
     @complete_count = UserCourse.completed_courses(@course.id)
-    # if @complete_count.nil? || @number_of_enrolled_count
-    #   flash.now[:alert] = 'Unable to find details about this course'
-    #   @courses = Course.all
-    #   render :index
-    # end
   end
 
   def enroll
@@ -35,19 +27,15 @@ class CoursesController < ApplicationController
       redirect_to @course
     else
       flash[:danger] = @enrolled.errors.full_messages
-
     end
   end
 
   def create
     @course = current_user.courses.new(course_params)
-
-    @recipent = @course.recipp(current_user)
-    # current_user.created_courses.map { |x| x.users.pluck(:email) }.flatten.uniq
-    # @recipent -= %w[cureent_user.email]
+    @recipent = current_user.recipp
 
     if @course.save
-      UserMailer.send_notification(@recipent, @course).deliver_now
+      # UserMailer.send_notification(@recipent, @course).deliver_now
       redirect_to courses_path, notice: 'Course Created '
     else
       flash[:danger] = @course.errors.full_messages

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -1,22 +1,23 @@
 module CoursesHelper
-  def datetime_format(localtime)
-    localtime.strftime('%A, %b %e, at %l:%M %p')
-    #                   week,month,day at hr,min,am/pm
-  end
+  # def datetime_format(localtime)
+  #   localtime.strftime('%A, %b %e, at %l:%M %p')
+  #   #                   week,month,day at hr,min,am/pm
+  # end
 
+  # TODO: need to refactor this current_subscription
   def current_subscription(id)
     current_user.subscriptions.find_by(course_id: id)
   end
 
-  def show_status(course)
-    current_subscription(course).status == 'completed' ? 'Completed' : 'In Progress'
-  end
+  # def show_status(course)
+  #   current_subscription(course).status == 'completed' ? 'Completed' : 'In Progress'
+  # end
 
-  def enrolled_at(course)
-    datetime_format current_subscription(course).created_at
-  end
+  # def enrolled_at(course)
+  #   datetime_format current_subscription(course).created_at
+  # end
 
-  def completed_at(course)
-    datetime_format current_subscription(course).updated_at
-  end
+  # def completed_at(course)
+  #   datetime_format current_subscription(course).updated_at
+  # end
 end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -4,19 +4,19 @@ module CoursesHelper
     #                   week,month,day at hr,min,am/pm
   end
 
-  def find_course(course)
-    current_user.user_courses.find_by(course_id: course.id)
+  def current_subscription(id)
+    current_user.subscriptions.find_by(course_id: id)
   end
 
   def show_status(course)
-    find_course(course).status == 'completed' ? 'Completed' : 'In Progress'
+    current_subscription(course).status == 'completed' ? 'Completed' : 'In Progress'
   end
 
   def enrolled_at(course)
-    datetime_format find_course(course).created_at
+    datetime_format current_subscription(course).created_at
   end
 
   def completed_at(course)
-    datetime_format find_course(course).updated_at
+    datetime_format current_subscription(course).updated_at
   end
 end

--- a/app/jobs/course_notification_job.rb
+++ b/app/jobs/course_notification_job.rb
@@ -2,6 +2,8 @@ class CourseNotificationJob < ApplicationJob
   queue_as :default
 
   def perform(recipent, course)
-    UserMailer.send_notification(recipent, course)
+    recipent.each do |email|
+      UserMailer.send_notification(email, course).deliver_later
+    end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,6 @@
 class UserMailer < ApplicationMailer
   def send_notification(recipent, course)
     @course = course
-    # binding.pry
     mail(
       to: recipent,
       subject: 'New Course Available'

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -31,14 +31,12 @@ class Course < ApplicationRecord
   # list the admin of the course
   belongs_to :owner, class_name: 'User', foreign_key: :user_id
 
-  before_save :capitalize_everything
-
-  after_save do
-    CourseNotificationJob.perform_later(owner.recipp, Course.last)
+  before_save do
+    self.language = language.capitalize
   end
 
-  def capitalize_everything
-    self.language = language.capitalize
+  after_save do
+    CourseNotificationJob.perform_later(Recipient.new(owner).list_of_recipient, Course.last)
   end
 
   scope :filter_course, ->(q) { where(language: q.capitalize) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,23 +34,4 @@ class User < ApplicationRecord
   has_many :main_courses, class_name: :Course
 
   enum :role, %i[member admin], default: :member
-
-  def enroll_in(id)
-    subscriptions.create(course_id: id)
-  end
-
-  # (will implement it using Service)
-  def recipp
-    main_courses.includes(:subscribers).map do |x|
-      x.subscribers.pluck(:email)
-    end.flatten.uniq - [email]
-  end
-
-  def already_enrolled?(id)
-    courses.include?(id)
-  end
-
-  def mark_as_(id)
-    subscriptions.find_by(course_id: id).update(status: 1)
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,22 +24,33 @@ class User < ApplicationRecord
          :recoverable, :validatable
   validates :name, presence: true
 
-  has_many :user_courses, dependent: :destroy
-  has_many :courses, through: :user_courses
+  #  courses in which user is regestered (join table)
+  has_many :subscriptions, class_name: 'UserCourse', dependent: :destroy
 
-  has_many :created_courses, class_name: :Course, foreign_key: :user_id
+  # list of courses with their name and language
+  has_many :courses, through: :subscriptions
+
+  # courses created by the user
+  has_many :main_courses, class_name: :Course
 
   enum :role, %i[member admin], default: :member
 
-  def enroll_in(course)
-    user_courses.create(course_id: course)
+  def enroll_in(id)
+    subscriptions.create(course_id: id)
   end
 
-  def already_enrolled?(course)
-    courses.include?(course)
+  # (will implement it using Service)
+  def recipp
+    main_courses.includes(:subscribers).map do |x|
+      x.subscribers.pluck(:email)
+    end.flatten.uniq - [email]
+  end
+
+  def already_enrolled?(id)
+    courses.include?(id)
   end
 
   def mark_as_(id)
-    user_courses.find_by(course_id: id).update(status: 1)
+    subscriptions.find_by(course_id: id).update(status: 1)
   end
 end

--- a/app/services/Enrollment/already_enrolled.rb
+++ b/app/services/Enrollment/already_enrolled.rb
@@ -1,0 +1,18 @@
+module Enrollment
+  class AlreadyEnrolled < ApplicationService
+    def initialize(course, user)
+      @course = course
+      @user = user
+    end
+
+    def call
+      @user.courses.include?(@course)
+    end
+
+    private
+
+    def already_enrolled?
+      AlreadyEnrolled.call(@course, @user)
+    end
+  end
+end

--- a/app/services/Enrollment/enroll_in.rb
+++ b/app/services/Enrollment/enroll_in.rb
@@ -1,0 +1,18 @@
+module Enrollment
+  class EnrollIn < ApplicationService
+    def initialize(course, user)
+      @course = course
+      @user = user
+    end
+
+    def call
+      @user.subscriptions.create(course_id: @course.id)
+    end
+
+    private
+
+    def enroll_in
+      EnrollIn.call(@course, @user)
+    end
+  end
+end

--- a/app/services/Enrollment/mark_as_complete.rb
+++ b/app/services/Enrollment/mark_as_complete.rb
@@ -1,0 +1,18 @@
+module Enrollment
+  class MarkAsComplete < ApplicationService
+    def initialize(course, user)
+      @course = course
+      @user = user
+    end
+
+    def call
+      @user.subscriptions.find_by(course_id: @course.id).update(status: 1)
+    end
+
+    private
+
+    def mark_as_complete
+      MarkAsComplete.call(@course, @user)
+    end
+  end
+end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,5 @@
+class ApplicationService
+  def self.call(*args)
+    new(*args).call
+  end
+end

--- a/app/services/recipient.rb
+++ b/app/services/recipient.rb
@@ -1,0 +1,15 @@
+class Recipient < ApplicationService
+  def initialize(owner)
+    @owner = owner
+  end
+
+  def call
+    @owner.main_courses.includes(:subscribers).map do |x|
+      x.subscribers.pluck(:email)
+    end.flatten.uniq - [@owner.email]
+  end
+
+  def list_of_recipient
+    Recipient.call(@owner)
+  end
+end

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -1,13 +1,7 @@
 <h1>Enter Course Details</h1>
 <br>
 <%= form_with  model: @course, url: { action: "create",controller: "courses" },method: :post do |f| %>
-  <% if @course.errors.any?  %>
-    <ul>
-      <% @course.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  <% end %>
+  <%= render "devise/shared/error_messages", resource:@course%>
   <div class="mb-3">
     <%= f.label :name, "Course name" %>
     <%= f.text_field :name ,placeholder: "Enter Your course name"%>
@@ -15,10 +9,10 @@
   <%= f.hidden_field :user_id, value: current_user.id %>
   <div class="mb-3">    <%= f.label :language, "Language" %>
     <%= f.text_field :language, placeholder: "Enter the programming langugae(like js ruby )" %></div>
-    <div class="mb-3">
+  <div class="mb-3">
     <%= f.label :cover, "Course Cover"%>
-   <%= f.file_field :cover%>
-    </div>
+    <%= f.file_field :cover%>
+  </div>
 
   <%= f.submit "Submit"%>
   <%# puts  params.inspect %>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -2,13 +2,17 @@
 <br>
 <%= form_with model: @course do |f| %>
   <div class="mb-3">
+    <%= render "devise/shared/error_messages", resource:@course%>
     <%= f.label :name, "Course name" %>
     <%= f.text_field :name ,placeholder: "Enter Your course name"%>
   </div>
   <%= f.hidden_field :user_id, value: current_user.id %>
-
   <div class="mb-3">    <%= f.label :language, "Language" %>
     <%= f.text_field :language, placeholder: "Enter the programming langugae(like js ruby )" %></div>
+  <div class="mb-3">
+    <%= f.label :cover, "Course Cover"%>
+    <%= f.file_field :cover%>
+  </div>
   <%= f.submit "Submit"%>
   <%# puts  params.inspect %>
 <% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 <hr>
 <h4>Course Name is <%=@course.name%></h4>
-<h4>Course creator Name is <%= @course.admin_user.name%></h4>
+<h4>Course creator Name is <%= @course.owner.name%></h4>
 <h4>Course language is <%=@course.language%></h4>
 <hr>
 <br>
@@ -21,15 +21,12 @@
 <h4>No of Enrolled users: <%=@number_of_enrolled_count %></h4>
 <hr>
 <br>
-<% if current_user.already_enrolled?(@course) %>
+<% if current_user.already_enrolled?(@course.id) %>
   <h1>Your are now enrolled in this  <%= @course.name%> course</h1>
-  <% current_user.user_courses.each do |course| %>
-    <% if current_user.id == course.user_id && @course.id == course.course_id%>
-      <h1>Here is your progress status: <%= course.status=="completed" ? "Completed":"In Progress"%></h1>
-      <% if course.status == "inprogress" %>
-        <%= button_to "Mark as Complete", mark_as_course_path , method: :patch , form: {data: {'turbo-confirm': "Are you sure"}}%>
-      <% end %>
-    <% end %>  <% end %>
+  <h1>Here is your progress status: <%= current_subscription(@Course.id).status=="completed" ? "Completed":"In Progress"%></h1>
+  <% if current_subscription(@Course.id).status == "inprogress" %>
+    <%= button_to "Mark as Complete", mark_as_course_path , method: :patch , form: {data: {'turbo-confirm': "Are you sure"}}%>
+  <% end %>
 <% else %>
   <%= button_to "Click Me(Enroll)",enroll_course_path,form: {data: {'turbo-confirm': "Are you sure"}}%>
 <% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -21,14 +21,15 @@
 <h4>No of Enrolled users: <%=@number_of_enrolled_count %></h4>
 <hr>
 <br>
-<% if current_user.already_enrolled?(@course.id) %>
+<%# <% if current_user.already_enrolled?(@course) %>
+<% if @regestered  %>
   <h1>Your are now enrolled in this  <%= @course.name%> course</h1>
-  <h1>Here is your progress status: <%= current_subscription(@Course.id).status=="completed" ? "Completed":"In Progress"%></h1>
-  <% if current_subscription(@Course.id).status == "inprogress" %>
+  <h1>Here is your progress status: <%= current_subscription(@course.id).status=="completed" ? "Completed":"In Progress"%></h1>
+  <% if current_subscription(@course.id).status == "inprogress" %>
     <%= button_to "Mark as Complete", mark_as_course_path , method: :patch , form: {data: {'turbo-confirm': "Are you sure"}}%>
   <% end %>
 <% else %>
-  <%= button_to "Click Me(Enroll)",enroll_course_path,form: {data: {'turbo-confirm': "Are you sure"}}%>
+  <%= button_to "Click Me(Enroll)",enroll_course_path%>
 <% end %>
 <%if current_user.admin? && @course.user_id == current_user.id %>
   <%= link_to "Edit this course", edit_course_path(@course)%>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -2,7 +2,6 @@
 <p><%= link_to 'All Courses', courses_path%></p>
 <h1>Course Content </h1>
 <hr>
-<%# binding.pry %>
 <% if @course.cover.attached? %>
   <%= image_tag @course.cover  , size: "1080x720"%>
 <% else %>
@@ -21,10 +20,9 @@
 <h4>No of Enrolled users: <%=@number_of_enrolled_count %></h4>
 <hr>
 <br>
-<%# <% if current_user.already_enrolled?(@course) %>
 <% if @regestered  %>
   <h1>Your are now enrolled in this  <%= @course.name%> course</h1>
-  <h1>Here is your progress status: <%= current_subscription(@course.id).status=="completed" ? "Completed":"In Progress"%></h1>
+  <h1>Here is your progress status: <%=  current_subscription(@course.id).status== "inprogress" ? t('in_progress_status') : t('completed_status') %></h1>
   <% if current_subscription(@course.id).status == "inprogress" %>
     <%= button_to "Mark as Complete", mark_as_course_path , method: :patch , form: {data: {'turbo-confirm': "Are you sure"}}%>
   <% end %>

--- a/app/views/layouts/_notifications.html.erb
+++ b/app/views/layouts/_notifications.html.erb
@@ -2,7 +2,7 @@
   <% if msg.is_a?(String) %>
     <div class="alert alert-<%= name.to_s == 'notice' ? 'success' : 'danger' %>">
       <button class="close" data-dismiss="alert">x</button>
-          <%= msg %>
+      <%= msg %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -25,11 +25,11 @@
     <h1>Courses,in which you are enrolled :<% @profile.courses.each do |c|%>    </h1>
       <hr>
       <p>Course Name => <%=link_to  c.name ,course_path(c.id)%></p>
-      <p>  Enrollment date => <%= enrolled_at(c)%></p>
-      <%if show_status(c) == "Completed" %>
-        <p>  Completed date => <%= completed_at(c)%></p>
+      <p>  Enrollment date => <%= l current_subscription(c.id).created_at, format: :custom %></p>
+      <%if current_subscription(c.id).status == "completed" %>
+        <p>  Completed date =><%= l current_subscription(c.id).updated_at, format: :custom %></p>
       <% end %>
-      <p>Show status => <%= show_status(c) %></p>
+      <p>Show status =>   <%=  current_subscription(c.id).status== "inprogress" ? t('in_progress_status') : t('completed_status') %> </p>
       <hr>
     <% end %>
   <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -11,7 +11,7 @@
     <br>
     <hr>
     <h1>Course Created by You</h1>
-    <% @profile.created_courses.each  do |course|%>
+    <% @profile.main_courses.each  do |course|%>
       <p>
         Name of the course : <%=link_to course.name, course_path(course.id) %>
       </p>

--- a/app/views/user_mailer/send_notification.html.erb
+++ b/app/views/user_mailer/send_notification.html.erb
@@ -5,13 +5,13 @@
   <%= image_tag @course.cover  , size: "1080x720"%>
 <% else %>
 
-  <%# <%=image_tag  'https://waifu.vercel.app/sfw/highfive' %>
-  <%= image_tag 'https://picsum.photos/seed/picsum/200/300' %>
+  <%=image_tag  'https://waifu.vercel.app/sfw/highfive' %>
+  <%# <%= image_tag 'https://picsum.photos/seed/picsum/200/300' %>
 
 <% end %>
 <hr>
 <h4>Course Name is <%=@course.name%></h4>
-<h4>Course creator Name is <%= @course.admin_user.name%></h4>
+<h4>Course creator Name is <%= @course.owner.name%></h4>
 <h4>Course language is <%=@course.language%></h4>
 <hr>
 <%= link_to "Click Me 👈🏻", course_url(@course.id)%>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '35e51c472d5504c0f0fa4c76e092dbbb010c65a9a94ce6729257e6dfce409ece83bd041ceee0440514803220d9201a80096b01a2c4116078429d350760bcb61c'
+  # config.secret_key = ''
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,8 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  in_progress_status: "In Progress"
+  completed_status: "Completed"
+  currency: "$%{p}"
+  time:
+    formats:
+      custom: "%A, %b %e, at %l:%M %p"
+  #           week,month,day at hr,min,am/pm

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,10 +14,10 @@ puts 'Seeding Users done.'
 
 puts 'Seeding Courses...'
 Course.create(language: 'js', name: 'course1', user_id: 4)
-Course.create(language: 'ruby', name: 'course2', user_id: 3)
-Course.create(language: 'php', name: 'course3', user_id: 3)
-Course.create(language: 'java', name: 'course4', user_id: 3)
+Course.create(language: 'ruby', name: 'course2', user_id: 1)
+Course.create(language: 'php', name: 'course3', user_id: 1)
+Course.create(language: 'java', name: 'course4', user_id: 1)
 Course.create(language: 'python', name: 'course5', user_id: 4)
-Course.create(language: 'R', name: 'course6', user_id: 3)
+Course.create(language: 'R', name: 'course6', user_id: 1)
 Course.create(language: 'haskell', name: 'course7', user_id: 4)
 puts 'Seeding Courses done.'


### PR DESCRIPTION
#For #[829213d](https://github.com/amnindersingh12/mycourse/pull/9/commits/829213dc91ccb56badc072c5b1db77d49cc85518)

Make use of service object, and separate some methods from controller and model.
1. Created two services 
   -  one for enrollment
       * create a Enrollment module
       * Add `Enroll In` method.
       * Add `Already Enrolled` method.
       * Add `Marks As Complete` method.
   - one to list all recipient
2. Use devise Error message partial to render errors.
   - during course creation
   - during update of course
3. Refactor `Course and User` model
4. Add `file upload` field in `course edit` form section.
5. Update name of some variables to make more sense. ( `is_admin` --> `require_admin`) 
i.e. to allow only `admin` to access certain action.

For #[a9facf0](https://github.com/amnindersingh12/mycourse/pull/9/commits/a9facf0bb701c2c53192e38d2ac0ba34df8c8890)

- [x] Refactor Course Helper method and use I18n 
- [x] Remove course helpers, `created_at`, `updated_at`, `show_status` method.
- [ ] DRY Course Helper, `current_subscription` method. 
```
def current_subscription(id)
    current_user.subscriptions.find_by(course_id: id)
end
```
* I have been using this code portion in my views to list the information about the join table between `User` and `Courses` 