### PR TITLE
Add Test cases for SuperUser feature 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,2 @@
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/Documentation:
-  Enabled: false
-Lint/MissingSuper:
-  Exclude:
-    - "app/services/**/*"
-# AllCops:
-#   Exclude:
-#     - "db/**/*"
 AllCops:
-  EnabledByDefault: true
-Style/Copyright:
-  Enabled: true
+  NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -85,8 +85,7 @@ gem 'cancancan'
 gem 'database_cleaner'
 gem 'devise'
 gem 'faker'
+gem 'htmlbeautifier'
 gem 'letter_opener', group: :development
 gem 'pry-rails'
 gem 'sidekiq'
-gem 'htmlbeautifier'
-

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,11 +10,13 @@ class Ability
     #   can :read, :all
     #   return unless user.admin?
 
-    can(%i[enroll read read mark_as], :all)
+    can(%i[enroll read mark_as], :all) if user.member?
 
     can(:manage, Course, user_id: user.id) if user.admin?
 
-    can(%i[update], Course, superuser_id: user.id)
+    can(:update, Course, superuser_id: user.id)
+
+    can(%i[read mark_as enroll], Course)
 
     #
     # The first argument to `can` is the action you are giving the user

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -19,7 +19,7 @@
     <%= f.text_field :name ,placeholder: "Enter Your course name"%>
   </div>
   <%= f.hidden_field :user_id, value: current_user.id %>
-  <% if current_user.id == @course.owner.id %>
+  <% if current_user == @course.owner %>
     <%= f.label :superuser_id, "SuperUser ID" %>
     <%= f.text_field :superuser_id, placeholder: "Enter User Id" %>
   <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 20_221_012_060_146) do
   create_table 'active_storage_attachments', force: :cascade do |t|
     t.string 'name', null: false
     t.string 'record_type', null: false
-    t.bigint 'record_id', null: false
-    t.bigint 'blob_id', null: false
+    t.integer 'record_id', null: false
+    t.integer 'blob_id', null: false
     t.datetime 'created_at', null: false
     t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
     t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
@@ -35,7 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 20_221_012_060_146) do
   end
 
   create_table 'active_storage_variant_records', force: :cascade do |t|
-    t.bigint 'blob_id', null: false
+    t.integer 'blob_id', null: false
     t.string 'variation_digest', null: false
     t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,8 +25,8 @@ puts 'Seeding Courses done.'
 puts 'Seeding UserCourse...'
 UserCourse.create(user_id: 4, course_id: 2)
 UserCourse.create(user_id: 2, course_id: 3)
-UserCourse.create( user_id: 3, course_id: 4)
-UserCourse.create( user_id: 1, course_id: 1)
+UserCourse.create(user_id: 3, course_id: 4)
+UserCourse.create(user_id: 1, course_id: 1)
 UserCourse.create(user_id: 3, course_id: 5)
 UserCourse.create(user_id: 2, course_id: 7)
 UserCourse.create(user_id: 4, course_id: 6)

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     language { 'Js' }
     name { "course_#{Faker::Name.first_name}" }
     user_id { 1 }
+    superuser_id { 1 }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -10,4 +10,10 @@ FactoryBot.define do
     password { 'password' }
     role { 'admin' }
   end
+  factory :super_user, class: 'user' do
+    name { "admin_#{Faker::Name.first_name}" }
+    email { "admin_#{Faker::Internet.email}" }
+    password { 'password' }
+    role { 'superuser' }
+  end
 end

--- a/spec/features/user_login_spec.rb
+++ b/spec/features/user_login_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'User', type: :feature do
+RSpec.feature('User', type: :feature) do
   given(:present_user) { create(:member_user) }
 
   feature 'Successful Login' do
@@ -11,7 +11,7 @@ RSpec.feature 'User', type: :feature do
         fill_in 'Password', with: present_user.password
       end
       click_button 'commit'
-      expect(page).to have_content 'Signed in successfully'
+      expect(page).to(have_content('Signed in successfully'))
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.feature 'User', type: :feature do
         fill_in 'Password', with: present_user.password
       end
       click_button 'commit'
-      expect(page).to have_content 'Invalid Email or password'
+      expect(page).to(have_content('Invalid Email or password'))
     end
     scenario 'Signing in with incorrect password' do
       visit '/auth/login'
@@ -32,7 +32,7 @@ RSpec.feature 'User', type: :feature do
         fill_in 'Password', with: '11111111'
       end
       click_button 'commit'
-      expect(page).to have_content 'Invalid Email or password'
+      expect(page).to(have_content('Invalid Email or password'))
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -28,29 +28,29 @@ describe Course, type: :model do
   it 'is invalid without a owner' do
     course = build(:course, user_id: nil)
     course.valid?
-    expect(course.errors[:owner]).to include('must exist')
+    expect(course.errors[:owner]).to(include('must exist'))
   end
 
   it 'is valid with name, language and Owner (user_id)' do
-    expect(build(:course, user_id: User.last.id)).to be_valid
+    expect(build(:course, user_id: User.last.id)).to(be_valid)
   end
 
   it 'is invalid without a name' do
     course = build(:course, name: nil)
     course.valid?
-    expect(course.errors[:name]).to include("can't be blank")
+    expect(course.errors[:name]).to(include("can't be blank"))
   end
 
   it 'is invalid without a language' do
     course = build(:course, language: nil)
     course.valid?
-    expect(course.errors[:language]).to include("can't be blank")
+    expect(course.errors[:language]).to(include("can't be blank"))
   end
 
   it 'is invalid with a duplicate name' do
     create(:course, name: 'user_xyz')
     course = build(:course, name: 'user_xyz')
     course.valid?
-    expect(course.errors[:name]).to include('has already been taken')
+    expect(course.errors[:name]).to(include('has already been taken'))
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,12 +18,64 @@
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 require 'rails_helper'
+require 'cancan/matchers'
 
-RSpec.describe User, type: :model do
+describe(User, type: :model) do
   context 'when name is valid' do
-    it { expect(build(:member_user)).to be_valid }
+    it { expect(build(:member_user)).to(be_valid) }
   end
   context 'when name is invalid' do
-    it { expect(build(:member_user, name: nil)).not_to be_valid }
+    it { expect(build(:member_user, name: nil)).not_to(be_valid) }
   end
+  describe 'abilities' do
+    subject(:ability) { Ability.new(user) }
+    let(:user) { build(:admin_user) }
+    let(:course) { build(:course) }
+
+    context 'when admin' do
+      describe 'can manage all action' do
+        let(:user) { build(:admin_user) }
+
+        it { is_expected.to(be_able_to(:manage, Course.new(user_id: user.id))) }
+      end
+    end
+
+    describe 'when member user' do
+      let(:user) { build(:member_user) }
+
+      context 'can read and enroll' do
+        %i[enroll read read mark_as].each do |role|
+          it { is_expected.to(be_able_to(role, Course.new)) }
+        end
+      end
+      context 'cannot manage' do
+        %i[create edit destroy].each do |role|
+          it { is_expected.not_to(be_able_to(role, course)) }
+        end
+      end
+    end
+
+    context 'when superuser' do
+      let(:user) { build(:super_user) }
+      context 'can read and enroll' do
+        %i[enroll read mark_as].each do |role|
+          it { is_expected.to(be_able_to(role, Course.new)) }
+        end
+      end
+      context 'can update' do
+        it { is_expected.to(be_able_to(:update, Course.new(superuser_id: user.id))) }
+      end
+      context 'cannot manage' do
+        %i[create destroy].each do |role|
+          it { is_expected.not_to(be_able_to(role, course)) }
+        end
+      end
+    end
+  end
+
+  # describe User do
+  #   it 'is available as described_class' do
+  #     expect(described_class).to(eq(User))
+  #   end
+  # end
 end

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -8,7 +8,8 @@ describe 'Courses', type: :request do
     {
       language: 'JJJ',
       name: 'course_111111',
-      user_id: 1
+      user_id: 1,
+      superuser_id: 1
     }
   end
 
@@ -16,38 +17,39 @@ describe 'Courses', type: :request do
     {
       language: 'Js',
       name: nil,
-      user_id: nil
+      user_id: nil,
+      superuser_id: nil
     }
   end
 
   describe 'GET /index' do
     it 'renders the index page' do
-      Course.create! valid_attributes
+      Course.create!(valid_attributes)
       get courses_path
-      expect(response).to be_successful
+      expect(response).to(be_successful)
     end
   end
 
   describe 'GET /show' do
     it 'renders the show page' do
-      course = Course.create! valid_attributes
+      course = Course.create!(valid_attributes)
       get courses_path(course)
-      expect(response).to be_successful
+      expect(response).to(be_successful)
     end
   end
 
   describe 'GET /new' do
     it 'renders the new page' do
       get new_course_path
-      expect(response).to be_successful
+      expect(response).to(be_successful)
     end
   end
 
   describe 'GET /edit' do
     it 'render a edit page' do
-      course = Course.create! valid_attributes
+      course = Course.create!(valid_attributes)
       get edit_course_path(course)
-      expect(response).to be_successful
+      expect(response).to(be_successful)
     end
   end
 
@@ -55,16 +57,27 @@ describe 'Courses', type: :request do
     context 'with valid parameters' do
       it 'creates a new course' do
         expect do
-          post courses_path, params: { course: valid_attributes }
-        end.to change(Course, :count).by(1)
+          post(courses_path, params: { course: valid_attributes })
+        end.to(change(Course, :count).by(1))
+      end
+      it 'redirects to the created course' do
+        post(courses_path, params: { course: valid_attributes })
+        expect(response).to(redirect_to(course_path(Course.last)))
       end
     end
 
     context 'with invalid parameters' do
       it 'does not create a new course' do
         expect do
-          post courses_path, params: { course: invalid_attributes }
-        end.to change(Course, :count).by(0)
+          post(courses_path, params: { course: invalid_attributes })
+        end.to(change(Course, :count).by(0))
+      end
+      it 'redirects to the new template' do
+        post(courses_path, params: { course: invalid_attributes })
+        expect(response).to(have_http_status(302))
+
+        # get new_course_path
+        # expect(response).to be_successful
       end
     end
 
@@ -74,45 +87,46 @@ describe 'Courses', type: :request do
           {
             language: 'New_Language',
             name: 'new_course',
-            user_id: 1
+            user_id: 1,
+            superuser_id: 1
           }
         end
 
         it 'updates the requested course' do
-          course = Course.create! valid_attributes
+          course = Course.create!(valid_attributes)
           patch course_path(course), params: { course: new_attributes }
           course.reload
-          expect(course.updated_at.to_s).to eq(Time.now.to_s)
+          expect(course.updated_at.to_s).to(eq(Time.now.to_s))
         end
 
         it 'redirects to the course' do
-          course = Course.create! valid_attributes
+          course = Course.create!(valid_attributes)
           patch course_path(course), params: { course: new_attributes }
           course.reload
-          expect(response).to redirect_to(course_path(course))
+          expect(response).to(redirect_to(course_path(course)))
         end
       end
 
       context 'with invalid parameters' do
         it "renders the 'edit' page again)" do
-          course = Course.create! valid_attributes
+          course = Course.create!(valid_attributes)
           patch course_path(course), params: { course: invalid_attributes }
-          expect(response.body).to include('Something Went Wrong!')
+          expect(response.body).to(include('Something Went Wrong!'))
         end
       end
     end
 
     describe 'DELETE /destroy' do
       it 'destroys the requested course' do
-        course = Course.create! valid_attributes
+        course = Course.create!(valid_attributes)
         expect do
-          delete course_path(course)
-        end.to change(Course, :count).by(-1)
+          delete(course_path(course))
+        end.to(change(Course, :count).by(-1))
       end
       it 'redirects to the root path' do
-        course = Course.create! valid_attributes
+        course = Course.create!(valid_attributes)
         delete course_path(course)
-        expect(response).to redirect_to(root_path)
+        expect(response).to(redirect_to(root_path))
       end
     end
   end

--- a/spec/routing/courses_routing_spec.rb
+++ b/spec/routing/courses_routing_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe CoursesController, type: :routing do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/courses').to(route_to('courses#index'))
+    end
+    it 'routes to #new' do
+      expect(get: '/courses/new').to(route_to('courses#new'))
+    end
+
+    it 'routes to #show' do
+      expect(get: '/courses/1').to(route_to('courses#show', id: '1'))
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/courses/1/edit').to(route_to('courses#edit', id: '1'))
+    end
+
+    it 'routes to #create' do
+      expect(post: '/courses').to(route_to('courses#create'))
+    end
+
+    it 'routes to #update' do
+      expect(patch: '/courses/1').to(route_to('courses#update', id: '1'))
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/courses/1').to(route_to('courses#destroy', id: '1'))
+    end
+    it 'routes to #enroll' do
+      expect(post: '/courses/1/enroll').to(route_to('courses#enroll', id: '1'))
+    end
+    it 'routes to #mark_as' do
+      expect(patch: '/courses/1/mark_as').to(route_to('courses#mark_as', id: '1'))
+    end
+  end
+end


### PR DESCRIPTION
1. Use cancan gem
2. Setup association between User and Course.
    - Course belongs to only one `superuser`
    - User can have many `SuperCourses`
    - using `superuser_id` as a foreign key
3. A normal user can be appointed as a superuser for a particular course. Course owner can edit the Course Details to change the `Super user`. Using a form to edit the Course details and course superuser.
    - <img width="716" alt="Screenshot 2022-10-12 at 6 54 53 PM" src="https://user-images.githubusercontent.com/45424062/195354702-8dac38bd-16ac-4a22-996d-c6d0b264e548.png">
    - A `list of enrolled users` will be provided, to `course owner`. It will `not be visible` to `normal superuser` while updating record.

5. A superuser can `only update` the details of the course, like `course name, course language and course cover`.
6. A `edit this course` link will be shown to the superuser to edit the course.
7.  superuser is only allowed to edit the certain page for which he has permissions granted. Superuser can not go to random page and edit like `courses/1/edit`. Doing so will redirect him to root page. Used Cancan gem.
8. Also, Course owner can only edit, destroy their own course.
9. By default, the Owner is the superuser and admin of the course.

- [ ]  Set user as SuperUser or Admin via UI. 
- [x] Writing Test Cases
